### PR TITLE
Fix popover profile duplicates, usage cards, and repositioning

### DIFF
--- a/src/ClaudeTracker/ViewModels/PopoverViewModel.cs
+++ b/src/ClaudeTracker/ViewModels/PopoverViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ClaudeTracker.Models;
+using ClaudeTracker.Services;
 using ClaudeTracker.Services.Interfaces;
 using ClaudeTracker.Utilities;
 
@@ -33,6 +34,7 @@ public partial class PopoverViewModel : ObservableObject
     [ObservableProperty] private string _lastUpdatedText = "";
     [ObservableProperty] private bool _isRefreshing;
     [ObservableProperty] private bool _hasCredentials;
+    [ObservableProperty] private bool _hasClaudeUsage;
     [ObservableProperty] private UsageStatusLevel _sessionStatus = UsageStatusLevel.Safe;
     [ObservableProperty] private UsageStatusLevel _weeklyStatus = UsageStatusLevel.Safe;
     public ObservableCollection<Profile> Profiles { get; } = new();
@@ -44,7 +46,7 @@ public partial class PopoverViewModel : ObservableObject
         _profileService = profileService;
         _refreshCoordinator = refreshCoordinator;
 
-        _profileService.ActiveProfileChanged += (_, _) => RefreshData();
+        _profileService.ActiveProfileChanged += (_, _) => { UpdateProfilesList(); RefreshData(); };
         _profileService.ProfilesChanged += (_, _) => UpdateProfilesList();
         _refreshCoordinator.RefreshStarted += (_, _) => IsRefreshing = true;
         _refreshCoordinator.RefreshCompleted += (_, _) =>
@@ -73,6 +75,7 @@ public partial class PopoverViewModel : ObservableObject
         HasCredentials = profile.HasUsageCredentials;
 
         var usage = profile.ClaudeUsage;
+        HasClaudeUsage = usage != null;
         if (usage != null)
         {
             var showRemaining = profile.IconConfig.ShowRemainingPercentage;
@@ -104,6 +107,18 @@ public partial class PopoverViewModel : ObservableObject
 
             LastUpdatedText = $"Updated {FormatterHelper.FormatTimeAgo(usage.LastUpdated)}";
         }
+        else
+        {
+            SessionPercentage = 0;
+            SessionPercentageText = "\u2014";
+            SessionResetText = "";
+            WeeklyPercentage = 0;
+            WeeklyPercentageText = "\u2014";
+            WeeklyResetText = "";
+            HasModelData = false;
+            HasCostData = false;
+            LastUpdatedText = "";
+        }
 
         var apiUsage = profile.ApiUsage;
         HasApiUsage = apiUsage != null;
@@ -117,8 +132,11 @@ public partial class PopoverViewModel : ObservableObject
 
     private void UpdateProfilesList()
     {
+        var source = _profileService.Profiles;
+        LoggingService.Instance.Log(
+            $"PopoverVM.UpdateProfilesList: source={source.Count}, collection={Profiles.Count}");
         Profiles.Clear();
-        foreach (var p in _profileService.Profiles)
+        foreach (var p in source)
             Profiles.Add(p);
     }
 }

--- a/src/ClaudeTracker/ViewModels/ProfilesViewModel.cs
+++ b/src/ClaudeTracker/ViewModels/ProfilesViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ClaudeTracker.Models;
+using ClaudeTracker.Services;
 using ClaudeTracker.Services.Interfaces;
 
 namespace ClaudeTracker.ViewModels;
@@ -20,6 +21,7 @@ public partial class ProfilesViewModel : ObservableObject
     {
         _profileService = profileService;
         _profileService.ProfilesChanged += (_, _) => RefreshList();
+        _profileService.ActiveProfileChanged += (_, _) => RefreshList();
         RefreshList();
     }
 
@@ -50,8 +52,11 @@ public partial class ProfilesViewModel : ObservableObject
 
     private void RefreshList()
     {
+        var source = _profileService.Profiles;
+        LoggingService.Instance.Log(
+            $"ProfilesVM.RefreshList: source={source.Count}, collection={Profiles.Count}");
         Profiles.Clear();
-        foreach (var p in _profileService.Profiles)
+        foreach (var p in source)
             Profiles.Add(p);
         OnPropertyChanged(nameof(ActiveProfileId));
     }

--- a/src/ClaudeTracker/Views/PopoverWindow.xaml.cs
+++ b/src/ClaudeTracker/Views/PopoverWindow.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Media;
 using Microsoft.Extensions.DependencyInjection;
 using ClaudeTracker.Models;
+using ClaudeTracker.Services;
 using ClaudeTracker.ViewModels;
 
 namespace ClaudeTracker.Views;
@@ -9,6 +10,7 @@ namespace ClaudeTracker.Views;
 public partial class PopoverWindow : Window
 {
     private readonly PopoverViewModel _viewModel;
+    private bool _suppressSelectionChanged;
 
     public event EventHandler? SwitchToWidgetRequested;
 
@@ -35,12 +37,22 @@ public partial class PopoverWindow : Window
         ProfileCombo.ItemsSource = _viewModel.Profiles;
         ProfileCombo.SelectionChanged += (_, _) =>
         {
-            if (ProfileCombo.SelectedValue is Guid id)
+            if (!_suppressSelectionChanged && ProfileCombo.SelectedValue is Guid id)
                 _viewModel.SwitchProfileCommand.Execute(id);
         };
 
         _viewModel.PropertyChanged += (_, _) => UpdateUI();
-        SizeChanged += (_, _) => UpdateProgressBars();
+        SizeChanged += (_, e) =>
+        {
+            UpdateProgressBars();
+            if (IsVisible && e.HeightChanged)
+            {
+                var workArea = SystemParameters.WorkArea;
+                var bottom = Top + e.PreviousSize.Height;
+                Top = bottom - ActualHeight;
+                Top = Math.Clamp(Top, workArea.Top + 4, workArea.Bottom - ActualHeight - 4);
+            }
+        };
         UpdateUI();
     }
 
@@ -48,13 +60,14 @@ public partial class PopoverWindow : Window
     {
         Dispatcher.Invoke(() =>
         {
+            _suppressSelectionChanged = true;
             ProfileCombo.SelectedValue =
                 App.Services.GetRequiredService<Services.Interfaces.IProfileService>().ActiveProfile?.Id;
+            _suppressSelectionChanged = false;
 
-            var hasCredentials = _viewModel.HasCredentials;
-            NoCredentialsPanel.Visibility = hasCredentials ? Visibility.Collapsed : Visibility.Visible;
-            SessionCard.Visibility = hasCredentials ? Visibility.Visible : Visibility.Collapsed;
-            WeeklyCard.Visibility = hasCredentials ? Visibility.Visible : Visibility.Collapsed;
+            NoCredentialsPanel.Visibility = _viewModel.HasCredentials ? Visibility.Collapsed : Visibility.Visible;
+            SessionCard.Visibility = _viewModel.HasClaudeUsage ? Visibility.Visible : Visibility.Collapsed;
+            WeeklyCard.Visibility = _viewModel.HasClaudeUsage ? Visibility.Visible : Visibility.Collapsed;
 
             // Session
             SessionPercentText.Text = _viewModel.SessionPercentageText;


### PR DESCRIPTION
## Summary
- **Fix profile dropdown duplicates**: Break cascading event loop (`UpdateUI` → `SelectionChanged` → `ActivateProfile` → `ActiveProfileChanged` → `UpdateProfilesList` → `PropertyChanged` → `UpdateUI` repeat) by suppressing `SelectionChanged` during programmatic `SelectedValue` updates
- **Hide Session/Weekly cards for API-key-only profiles**: New `HasClaudeUsage` property controls card visibility instead of `HasCredentials`, preventing misleading "0%" display. Stale fields reset to defaults when usage is null
- **Fix Activate button in Settings Profiles tab**: `ProfilesViewModel` now subscribes to `ActiveProfileChanged` (was only listening to `ProfilesChanged`)
- **Fix popover floating away from taskbar**: Pin bottom edge on `SizeChanged` when card visibility changes alter the popover height
- **Add diagnostic logging** to profile list refresh methods for count tracking

## Test plan
- [ ] Start app → open popover → verify profile dropdown shows correct count (no duplicates)
- [ ] Create API-key-only profile → Session/Weekly cards hidden, only API Credits card shows
- [ ] Switch profiles via popover ComboBox → cards update correctly, no stale "0%"
- [ ] Open Settings → Profiles tab → click Activate → badge and button update immediately
- [ ] Toggle between profiles with different credential types → popover stays anchored to taskbar
- [ ] Check `%APPDATA%\ClaudeTracker\logs\` for `UpdateProfilesList`/`RefreshList` log entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)