### PR TITLE
fix: rate limit backoff, overlap guard, faster popup dismiss (v2.0.3)

### DIFF
--- a/src/ClaudeTracker/ClaudeTracker.csproj
+++ b/src/ClaudeTracker/ClaudeTracker.csproj
@@ -9,9 +9,9 @@
     <ApplicationIcon>Assets\app_icon.ico</ApplicationIcon>
     <AssemblyName>ClaudeTracker</AssemblyName>
     <RootNamespace>ClaudeTracker</RootNamespace>
-    <Version>2.0.2</Version>
-    <AssemblyVersion>2.0.2.0</AssemblyVersion>
-    <FileVersion>2.0.2.0</FileVersion>
+    <Version>2.0.3</Version>
+    <AssemblyVersion>2.0.3.0</AssemblyVersion>
+    <FileVersion>2.0.3.0</FileVersion>
     <Description>Claude AI Usage Tracker for Windows</Description>
     <Authors>TobiiNT</Authors>
     <Company>Tobii Development</Company>

--- a/src/ClaudeTracker/Services/HookIpcService.cs
+++ b/src/ClaudeTracker/Services/HookIpcService.cs
@@ -327,7 +327,7 @@ public class HookIpcService : IHookIpcService
         {
             while (!ct.IsCancellationRequested && !disconnectTcs.Task.IsCompleted)
             {
-                await Task.Delay(500, ct);
+                await Task.Delay(100, ct);
 
                 if (!pipe.IsConnected)
                 {

--- a/src/ClaudeTracker/Services/UsageRefreshCoordinator.cs
+++ b/src/ClaudeTracker/Services/UsageRefreshCoordinator.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using System.Windows.Threading;
 using ClaudeTracker.Models;
 using ClaudeTracker.Services.Interfaces;
@@ -14,6 +15,8 @@ public class UsageRefreshCoordinator : IUsageRefreshCoordinator, IDisposable
     private DispatcherTimer? _timer;
     private ClaudeStatus _cachedStatus = ClaudeStatus.Unknown;
     private DateTime _lastStatusFetch = DateTime.MinValue;
+    private bool _isRefreshing;
+    private DateTime _rateLimitedUntil = DateTime.MinValue;
 
     public bool IsRunning => _timer?.IsEnabled ?? false;
     public ClaudeStatus CurrentStatus => _cachedStatus;
@@ -79,9 +82,21 @@ public class UsageRefreshCoordinator : IUsageRefreshCoordinator, IDisposable
 
     private async Task RefreshAsync()
     {
+        if (_isRefreshing) return; // Prevent overlapping requests
+
+        // Skip if rate-limited — don't make requests that extend the limit
+        if (DateTime.UtcNow < _rateLimitedUntil)
+        {
+            LoggingService.Instance.Log($"Skipping refresh — rate limited until {_rateLimitedUntil:HH:mm:ss}");
+            return;
+        }
+
+        _isRefreshing = true;
+
         var profile = _profileService.ActiveProfile;
         if (profile == null || !profile.HasUsageCredentials)
         {
+            _isRefreshing = false;
             return;
         }
 
@@ -116,10 +131,21 @@ public class UsageRefreshCoordinator : IUsageRefreshCoordinator, IDisposable
 
             RefreshCompleted?.Invoke(this, EventArgs.Empty);
         }
+        catch (HttpRequestException ex) when (ex.Message.Contains("Rate limited"))
+        {
+            // Back off for 5 minutes on rate limit — don't extend it with retries
+            _rateLimitedUntil = DateTime.UtcNow.AddMinutes(5);
+            LoggingService.Instance.LogWarning($"Rate limited — backing off until {_rateLimitedUntil:HH:mm:ss}");
+            RefreshFailed?.Invoke(this, "Rate limited — retrying in 5 minutes");
+        }
         catch (Exception ex)
         {
             LoggingService.Instance.LogError("Usage refresh failed", ex);
             RefreshFailed?.Invoke(this, ex.Message);
+        }
+        finally
+        {
+            _isRefreshing = false;
         }
     }
 


### PR DESCRIPTION
## Summary

- **Rate limit backoff** — 5-minute cooldown on 429 response, stops retry spiral that extends rate limiting
- **Overlap guard** — `_isRefreshing` flag prevents concurrent API requests from timer + manual refresh
- **Faster popup dismiss** — pipe disconnect poll reduced from 500ms to 100ms, popup closes near-instantly when user answers in terminal

## Test plan

- [x] Build succeeds
- [x] Rate limit exception triggers 5-min backoff (verified in code path)
- [x] Overlapping RefreshNow calls are skipped
- [x] Popup dismiss speed improved