### PR TITLE
feat: Terminal button brings matching terminal to foreground (v2.0.4)

### DIFF
--- a/src/ClaudeTracker/ClaudeTracker.csproj
+++ b/src/ClaudeTracker/ClaudeTracker.csproj
@@ -9,9 +9,9 @@
     <ApplicationIcon>Assets\app_icon.ico</ApplicationIcon>
     <AssemblyName>ClaudeTracker</AssemblyName>
     <RootNamespace>ClaudeTracker</RootNamespace>
-    <Version>2.0.3</Version>
-    <AssemblyVersion>2.0.3.0</AssemblyVersion>
-    <FileVersion>2.0.3.0</FileVersion>
+    <Version>2.0.4</Version>
+    <AssemblyVersion>2.0.4.0</AssemblyVersion>
+    <FileVersion>2.0.4.0</FileVersion>
     <Description>Claude AI Usage Tracker for Windows</Description>
     <Authors>TobiiNT</Authors>
     <Company>Tobii Development</Company>

--- a/src/ClaudeTracker/Views/PermissionRequestPopup.xaml.cs
+++ b/src/ClaudeTracker/Views/PermissionRequestPopup.xaml.cs
@@ -1,4 +1,6 @@
 using System.Media;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
 using System.Windows;
 using System.Windows.Controls;
@@ -681,6 +683,8 @@ public partial class PermissionRequestPopup : Window
 
     private void Terminal_Click(object sender, RoutedEventArgs e)
     {
+        // Try to bring the matching terminal window to foreground
+        BringTerminalToFront(_info.Cwd);
         SetDecision(new PermissionDecisionResult { Decision = PermissionDecision.HandleInTerminal });
     }
 
@@ -775,6 +779,77 @@ public partial class PermissionRequestPopup : Window
             return $"{kvp.Key}: {val}";
         });
         return string.Join("\n", parts);
+    }
+
+    // ── Bring terminal window to foreground ──
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+    [DllImport("user32.dll")]
+    private static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
+    private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    // Terminal process names that could host Claude Code
+    private static readonly HashSet<string> TerminalProcesses = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "WindowsTerminal", "cmd", "powershell", "pwsh",
+        "Code",       // VS Code
+        "Hyper", "Alacritty", "wezterm-gui", "ConEmu", "ConEmu64"
+    };
+
+    private static void BringTerminalToFront(string cwd)
+    {
+        if (string.IsNullOrEmpty(cwd)) return;
+
+        var projectName = System.IO.Path.GetFileName(cwd) ?? cwd;
+        IntPtr found = IntPtr.Zero;
+
+        EnumWindows((hWnd, _) =>
+        {
+            if (!IsWindowVisible(hWnd)) return true;
+
+            // Only consider terminal processes
+            try
+            {
+                GetWindowThreadProcessId(hWnd, out uint pid);
+                var proc = System.Diagnostics.Process.GetProcessById((int)pid);
+                if (!TerminalProcesses.Contains(proc.ProcessName))
+                    return true;
+            }
+            catch { return true; }
+
+            var sb = new StringBuilder(512);
+            GetWindowText(hWnd, sb, sb.Capacity);
+            var title = sb.ToString();
+
+            if (title.Contains(cwd, StringComparison.OrdinalIgnoreCase) ||
+                title.Contains(projectName, StringComparison.OrdinalIgnoreCase))
+            {
+                found = hWnd;
+                return false;
+            }
+            return true;
+        }, IntPtr.Zero);
+
+        if (found != IntPtr.Zero)
+        {
+            ShowWindow(found, 9); // SW_RESTORE
+            SetForegroundWindow(found);
+        }
     }
 
     // Helper types for AskUserQuestion parsing


### PR DESCRIPTION
## Summary

- **Terminal button focus** — clicking "Terminal" in permission popup now finds and brings the matching VS Code / terminal window to foreground using Win32 EnumWindows
- Filters to terminal processes only (VS Code, Windows Terminal, PowerShell, cmd, etc.) — excludes Visual Studio, browsers
- Matches window title against project cwd/name from hook event
- Falls back gracefully if no match found

## Test plan

- [x] Correct VS Code instance brought to front
- [x] Visual Studio excluded from matching
- [x] No crash when no matching window found